### PR TITLE
Explode data: attribute

### DIFF
--- a/lib/tubby.rb
+++ b/lib/tubby.rb
@@ -56,8 +56,17 @@ module Tubby
 
     def __attrs!(attrs)
       if attrs.key?(:data) && attrs[:data].is_a?(Hash)
-        attrs = attrs.merge(attrs.delete(:data).transform_keys { |k| "data-#{k}" })
+        # Flatten present `data: {k1: v1, k2: v2}` attribute, inserting `data-k1: v1, data-k2: v2`
+        # into exact place where the attribute was
+        attrs = attrs.map do |key, value|
+          if key == :data && value.is_a?(Hash)
+            value.map { |k, v| [:"data-#{k}", v] }
+          else
+            [[key, value]]
+          end
+        end.flatten(1).to_h
       end
+
       attrs.each do |key, value|
         if value.is_a?(Array)
           value = value.compact.join(" ")

--- a/lib/tubby.rb
+++ b/lib/tubby.rb
@@ -58,13 +58,13 @@ module Tubby
       if attrs.key?(:data) && attrs[:data].is_a?(Hash)
         # Flatten present `data: {k1: v1, k2: v2}` attribute, inserting `data-k1: v1, data-k2: v2`
         # into exact place where the attribute was
-        attrs = attrs.map do |key, value|
+        attrs = Hash[attrs.map do |key, value|
           if key == :data && value.is_a?(Hash)
             value.map { |k, v| [:"data-#{k}", v] }
           else
             [[key, value]]
           end
-        end.flatten(1).to_h
+        end.flatten(1)]
       end
 
       attrs.each do |key, value|

--- a/lib/tubby.rb
+++ b/lib/tubby.rb
@@ -55,6 +55,9 @@ module Tubby
     end
 
     def __attrs!(attrs)
+      if attrs.key?(:data) && attrs[:data].is_a?(Hash)
+        attrs = attrs.merge(attrs.delete(:data).transform_keys { |k| "data-#{k}" })
+      end
       attrs.each do |key, value|
         if value.is_a?(Array)
           value = value.compact.join(" ")

--- a/lib/tubby.rb
+++ b/lib/tubby.rb
@@ -58,13 +58,13 @@ module Tubby
       if attrs.key?(:data) && attrs[:data].is_a?(Hash)
         # Flatten present `data: {k1: v1, k2: v2}` attribute, inserting `data-k1: v1, data-k2: v2`
         # into exact place where the attribute was
-        attrs = Hash[attrs.map do |key, value|
+        attrs = Hash[attrs.flat_map do |key, value|
           if key == :data && value.is_a?(Hash)
             value.map { |k, v| [:"data-#{k}", v] }
           else
             [[key, value]]
           end
-        end.flatten(1)]
+        end]
       end
 
       attrs.each do |key, value|
@@ -146,4 +146,3 @@ module Tubby
     end
   end
 end
-

--- a/test/test_tubby.rb
+++ b/test/test_tubby.rb
@@ -98,6 +98,14 @@ class TestTubby < Minitest::Test
     assert_equal '<h1 c="" d="123" e="" f="1 false 2" g></h1>', tmpl.to_s
   end
 
+  def test_data_attrs
+    tmpl = Tubby.new { |t|
+      t.div(class: %w[a b], data: {attr1: 'a', attr2: 1})
+    }
+
+    assert_equal '<div class="a b" data-attr1="a" data-attr2="1"></div>', tmpl.to_s
+  end
+
   class HTMLBuffer < String
     def html_safe?
       @html_safe == true

--- a/test/test_tubby.rb
+++ b/test/test_tubby.rb
@@ -100,10 +100,20 @@ class TestTubby < Minitest::Test
 
   def test_data_attrs
     tmpl = Tubby.new { |t|
-      t.div(class: %w[a b], data: {attr1: 'a', attr2: 1})
+      t.div(class: %w[a b], data: {attr1: 'a', attr2: 1}, id: 'foo')
     }
 
-    assert_equal '<div class="a b" data-attr1="a" data-attr2="1"></div>', tmpl.to_s
+    assert_equal '<div class="a b" data-attr1="a" data-attr2="1" id="foo"></div>', tmpl.to_s
+
+    # testing order of data attributes and rewriting of each other:
+    assert_equal '<div data-attr1="a" data-attr2="b"></div>',
+                 Tubby.new { |t| t.div(data: {attr1: 'a'}, 'data-attr2': 'b') }.to_s
+    assert_equal '<div data-attr2="b" data-attr1="a"></div>',
+                 Tubby.new { |t| t.div('data-attr2': 'b', data: {attr1: 'a'}) }.to_s
+    assert_equal '<div data-attr1="b"></div>',
+                 Tubby.new { |t| t.div(data: {attr1: 'a'}, 'data-attr1': 'b') }.to_s
+    assert_equal '<div data-attr1="a"></div>',
+                 Tubby.new { |t| t.div('data-attr1': 'b', data: {attr1: 'a'}) }.to_s
   end
 
   class HTMLBuffer < String

--- a/test/test_tubby.rb
+++ b/test/test_tubby.rb
@@ -107,13 +107,13 @@ class TestTubby < Minitest::Test
 
     # testing order of data attributes and rewriting of each other:
     assert_equal '<div data-attr1="a" data-attr2="b"></div>',
-                 Tubby.new { |t| t.div(data: {attr1: 'a'}, 'data-attr2': 'b') }.to_s
+                 Tubby.new { |t| t.div(data: {attr1: 'a'}, :'data-attr2' => 'b') }.to_s
     assert_equal '<div data-attr2="b" data-attr1="a"></div>',
-                 Tubby.new { |t| t.div('data-attr2': 'b', data: {attr1: 'a'}) }.to_s
+                 Tubby.new { |t| t.div(:'data-attr2' => 'b', data: {attr1: 'a'}) }.to_s
     assert_equal '<div data-attr1="b"></div>',
-                 Tubby.new { |t| t.div(data: {attr1: 'a'}, 'data-attr1': 'b') }.to_s
+                 Tubby.new { |t| t.div(data: {attr1: 'a'}, :'data-attr1' => 'b') }.to_s
     assert_equal '<div data-attr1="a"></div>',
-                 Tubby.new { |t| t.div('data-attr1': 'b', data: {attr1: 'a'}) }.to_s
+                 Tubby.new { |t| t.div(:'data-attr1' => 'b', data: {attr1: 'a'}) }.to_s
   end
 
   class HTMLBuffer < String


### PR DESCRIPTION
Thanks for the amazing library! We are using it in production a lot, and I really love how small and focused and no-magic it is.
So here I am with a feature proposal :joy:

What I am missing in the current functionality is "data"-attributes: It is frequently necessary to put some data in a "widget", and the usual agreement in a lot of templating languages, that `data: {foo: 1, bar: 2}` attrs are rendered as `data-foo='1' data-bar='2'` in HTML.

So, I propose to add it. The change seems to be small enough (but I understand if you are feeling uneasy about expanding the functionality).